### PR TITLE
Remove git conflicts from text-classification.ipynb

### DIFF
--- a/src/notebooks/text-classification.ipynb
+++ b/src/notebooks/text-classification.ipynb
@@ -56,15 +56,7 @@
    "metadata": {},
    "source": [
     "### !! Running this notebook with a pre-trained TART head !!\n",
-<<<<<<< HEAD
-<<<<<<< HEAD
     "* Download [pre-trained TART Reasoning module](https://github.com/HazyResearch/TART/releases/download/initial_release/tart_heads.zip)  --- see the cell below\n",
-=======
-    "* Download [pre-trained TART Reasoning module](https://github.com/HazyResearch/TART/releases/download/reasoning_module/tart_heads.zip)  --- see the cell below\n",
->>>>>>> e2251a9... Initial commit
-=======
-    "* Download [pre-trained TART Reasoning module](https://github.com/HazyResearch/TART/releases/download/reasoning_module/tart_heads.zip)  --- see the cell below\n",
->>>>>>> 2e3fcd0b814086fa75dfe929111f1573812a512b
     "\n",
     "* Set the location of the downloaded module to `path_tart_weights` in the cell below"
    ]
@@ -75,15 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-<<<<<<< HEAD
-<<<<<<< HEAD
     "! wget https://github.com/HazyResearch/TART/releases/download/initial_release/tart_heads.zip\n",
-=======
-    "! wget https://github.com/HazyResearch/TART/releases/download/reasoning_module/tart_heads.zip\n",
->>>>>>> e2251a9... Initial commit
-=======
-    "! wget https://github.com/HazyResearch/TART/releases/download/reasoning_module/tart_heads.zip\n",
->>>>>>> 2e3fcd0b814086fa75dfe929111f1573812a512b
     "! unzip tart_heads.zip"
    ]
   },


### PR DESCRIPTION
Thanks for sharing the code, this is really cool work! 

In this PR, I just remove git-generated conflict markers from `text-classification.ipynb`.  This allows the notebook to be opened with Jupyter. Please check if the notebook looks correct now.